### PR TITLE
Unify the relocations loading (#16705)

### DIFF
--- a/libr/bin/format/elf/elf.h
+++ b/libr/bin/format/elf/elf.h
@@ -110,8 +110,9 @@ struct Elf_(r_bin_elf_obj_t) {
 	char *shstrtab;
 
 	Elf_(Dyn) *dyn_buf;
-	RBinElfDynamicInfo dyn_info;
 	int dyn_entries;
+	RBinElfDynamicInfo dyn_info;
+	RBinElfReloc *relocs;
 	ut32 reloc_num;
 
 	ut64 version_info[DT_VERSIONTAGNUM];

--- a/libr/bin/p/bin_elf.inc
+++ b/libr/bin/p/bin_elf.inc
@@ -697,7 +697,6 @@ static RList* relocs(RBinFile *bf) {
 			}
 			r_list_append (ret, ptr);
 		}
-		free (relocs);
 	}
 	return ret;
 }
@@ -908,13 +907,11 @@ static RList* patch_relocs(RBin *b) {
 		return NULL;
 	}
 	if (!(ret = r_list_newf ((RListFree)free))) {
-		free (relcs);
 		return NULL;
 	}
 	HtUUOptions opt = { 0 };
 	if (!(relocs_by_sym = ht_uu_new_opt (&opt))) {
 		r_list_free (ret);
-		free (relcs);
 		return NULL;
 	}
 	vaddr = n_vaddr;
@@ -944,7 +941,6 @@ static RList* patch_relocs(RBin *b) {
 		r_list_append (ret, ptr);
 	}
 	ht_uu_free (relocs_by_sym);
-	free (relcs);
 	return ret;
 }
 


### PR DESCRIPTION
* Mov init rel_cache inside the bin init
* Introduce array cache
* Use bin->relocs after loading all relocs
* Handle bin->relocs == NULL
* Remove last free
* Use cache to get relocations

 <!-- Filling this template is mandatory -->

**Your checklist for this pull request**
- [ ] I've read the [guidelines for contributing](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md) to this repository
- [ ] I made sure to follow the project's [coding style](https://github.com/radareorg/radare2/blob/master/DEVELOPERS.md#code-style)
- [ ] I've added tests that prove my fix is effective or that my feature works (if possible)
- [ ] I've updated the documentation and the [radare2 book](https://github.com/radareorg/radare2book) with the relevant information (if needed)

**Detailed description**

<!-- Explain the **details** for making this change. Is a new feature implemented? What existing problem does the pull request solve? How does the pull request solve these issues? Please provide enough information so that others can review your pull request. -->

...

**Test plan**

<!-- What steps should the reviewer take to test your pull request? Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots/videos. This is your time to re-check that everything works and that you covered all the edge cases -->

...

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
